### PR TITLE
Add Flask app with belt history

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests

--- a/website/__init__.py
+++ b/website/__init__.py
@@ -1,0 +1,5 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+from . import routes  # noqa: E402

--- a/website/belt_history.json
+++ b/website/belt_history.json
@@ -1,0 +1,3 @@
+[
+  {"date": "1933-12-01", "champion": "Alabama"}
+]

--- a/website/belt_history.py
+++ b/website/belt_history.py
@@ -1,0 +1,85 @@
+import json
+import os
+from datetime import date
+from typing import List, Dict, Optional
+import requests
+
+BELT_HISTORY_FILE = os.path.join(os.path.dirname(__file__), 'belt_history.json')
+
+
+def load_history() -> List[Dict[str, str]]:
+    if os.path.exists(BELT_HISTORY_FILE):
+        with open(BELT_HISTORY_FILE, 'r') as f:
+            return json.load(f)
+    return []
+
+
+def save_history(history: List[Dict[str, str]]) -> None:
+    with open(BELT_HISTORY_FILE, 'w') as f:
+        json.dump(history, f, indent=2)
+
+
+def get_current_champion() -> Optional[str]:
+    history = load_history()
+    return history[-1]['champion'] if history else None
+
+
+def add_new_champion(champion: str, game_date: str) -> None:
+    history = load_history()
+    history.append({'date': game_date, 'champion': champion})
+    save_history(history)
+
+
+def update_belt() -> Optional[str]:
+    """Check an external sports API to update the belt holder.
+
+    This implementation uses the College Football Data API. The function
+    fetches today's games for the current champion and updates the belt
+    history if the champion loses.
+    """
+    champion = get_current_champion()
+    if not champion:
+        return None
+
+    today = date.today()
+    url = 'https://api.collegefootballdata.com/games'
+    params = {
+        'year': today.year,
+        'team': champion,
+        'startDate': today.isoformat(),
+        'endDate': today.isoformat(),
+    }
+
+    try:
+        response = requests.get(url, params=params, timeout=10)
+        response.raise_for_status()
+        games = response.json()
+    except Exception as exc:  # pragma: no cover - network call not tested
+        print(f'Could not update belt: {exc}')
+        return None
+
+    if not games:
+        # Champion did not play today
+        return champion
+
+    game = games[0]
+    home_team = game.get('home_team')
+    away_team = game.get('away_team')
+    home_score = game.get('home_points', 0)
+    away_score = game.get('away_points', 0)
+
+    if champion == home_team:
+        champion_score, opponent_score = home_score, away_score
+        opponent_team = away_team
+    else:
+        champion_score, opponent_score = away_score, home_score
+        opponent_team = home_team
+
+    if champion_score is None or opponent_score is None:
+        return champion
+
+    if champion_score < opponent_score:
+        add_new_champion(opponent_team, today.isoformat())
+        return opponent_team
+
+    return champion

--- a/website/routes.py
+++ b/website/routes.py
@@ -1,0 +1,11 @@
+from flask import render_template
+
+from . import app
+from .belt_history import load_history, get_current_champion, update_belt
+
+@app.route('/belt')
+def belt():
+    update_belt()
+    history = load_history()
+    current = get_current_champion()
+    return render_template('belt.html', history=history, current=current)

--- a/website/run.py
+++ b/website/run.py
@@ -1,0 +1,4 @@
+from . import app
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/website/templates/belt.html
+++ b/website/templates/belt.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SEC Championship Belt</title>
+</head>
+<body>
+    <h1>Current Champion: {{ current }}</h1>
+    <h2>History</h2>
+    <ul>
+    {% for item in history %}
+        <li>{{ item.date }} - {{ item.champion }}</li>
+    {% endfor %}
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement a basic Flask site under `website/`
- store champions in JSON with helper functions
- update belt logic stub with collegefootballdata API example
- expose `/belt` route that shows current champion and history
- add `requirements.txt`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a24ab5f2083229b958ee214aba454